### PR TITLE
add Aanderaa2018 and remove Presens XXX 

### DIFF
--- a/oxygen.bib
+++ b/oxygen.bib
@@ -282,3 +282,15 @@ doi = {},
 url = {http://nora.nerc.ac.uk/id/eprint/514980/},
 year = {2016}
 }
+
+@article{Aanderaa2018,
+author = {Aanderaa Data Instruments AS},
+title = {Aanderaa Oxygen Optodes: Best Practices for Maintaining High Data Quality.},
+journal = {Aanderaa Data Instruments AS, Bergen, Norway},
+volume = {},
+number = {},
+pages = {28pp},
+doi = {http://dx.doi.org/10.25607/OBP-868},
+url = {https://www.aanderaa.com/media/pdfs/aanderaa-oxygen-optodes-best-practices-calib-info-literature-list.pdf},
+year = {2018}
+}

--- a/oxygen.md
+++ b/oxygen.md
@@ -153,7 +153,7 @@ Deployments in the Bornholm Basin have shown good agreement across a wide range 
 # Pre-deployment operations and calibrations
 
 ## Storage and cleaning
-Optode foils typically drift more while in storage than while in use, the reasons for this are thought to be due to exposure to UV radiation and dry air [@Bittig2018], Presens XXXX and (Aanderaa). 
+Optode foils typically drift more while in storage than while in use, the reasons for this are thought to be due to exposure to UV radiation and dry air [@Bittig2018], [@Aanderaa2018]. 
 We recommend that all optodes should be stored away from the light (especially fluorescent lights), keep the foil humid and use the plastic caps provided with the sensor. Two-point calibration prior to deployment is always recommended.
 Sensors should be cleaned before storage and stored with black caps on including some tap water, or with a piece of wet cotton taped against the foil. 
 If sensors are stored dry the foil will dry out which could lead to 1-2 % lower readings. 


### PR DESCRIPTION
I added the Aanderaa2018 citation to oxygen.bib and linked it in the text and remove the Presens XXXX in the text as I cannot find proper citations on the sensor company page. But the Aanderaa document is quite exhaustive. 