### PR TITLE
Copyright/license in the book deployment

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -19,3 +19,4 @@ bibtex_bibfiles:
 sphinx:
   config:
     bibtex_reference_style: author_year
+    html_show_copyright: false

--- a/_config.yml
+++ b/_config.yml
@@ -3,8 +3,7 @@ title: "Oxygen SOP"
 copyright: "2022"
 logo: images/logo-ocean-gliders.png
 html:
-  extra_footer:
-  <p> By the OceanGliders community using <a href="https://jupyterbook.org/intro.html"   target="_blank">Jupyter Book</a>. This work is licensed under a <a href="https://creativecommons.org/licenses/by/4.0/" target="_blank"> Creative Commons Attribution 4.0 Generic License.</a> </p>
+  extra_footer: | <p> By the OceanGliders community using <a href="https://jupyterbook.org/intro.html"   target="_blank">Jupyter Book</a>. This work is licensed under a <a href="https://creativecommons.org/licenses/by/4.0/" target="_blank"> Creative Commons Attribution 4.0 Generic License.</a> </p>
 
 execute:
   execute_notebooks: "off"

--- a/_config.yml
+++ b/_config.yml
@@ -1,6 +1,5 @@
 title: "Oxygen SOP"
-#author: The OceanGliders community
-copyright: "2022"
+copyright: ""
 logo: images/logo-ocean-gliders.png
 html:
   extra_footer: |

--- a/_config.yml
+++ b/_config.yml
@@ -1,13 +1,6 @@
 title: "Oxygen SOP"
 copyright: ""
 logo: images/logo-ocean-gliders.png
-html:
-  extra_footer: |
-    <p>  By the OceanGliders community using
-      <a href="https://jupyterbook.org/intro.html"   target="_blank">Jupyter Book</a>. 
-      This work is licensed under a 
-      <a href="https://creativecommons.org/licenses/by/4.0/" target="_blank"> Creative Commons Attribution 4.0 Generic License.</a> 
-    </p>
 
 execute:
   execute_notebooks: "off"
@@ -21,6 +14,13 @@ html:
   comments:
     utterances:
       repo: "OceanGlidersCommunity/Oxygen_SOP"
+  extra_footer: |
+    <p>  By the OceanGliders community using
+      <a href="https://jupyterbook.org/intro.html"   target="_blank">Jupyter Book</a>. 
+      This work is licensed under a 
+      <a href="https://creativecommons.org/licenses/by/4.0/" target="_blank"> Creative Commons Attribution 4.0 Generic License.</a> 
+    </p>
+    
 bibtex_bibfiles:
     - oxygen.bib
 sphinx:

--- a/_config.yml
+++ b/_config.yml
@@ -3,7 +3,12 @@ title: "Oxygen SOP"
 copyright: "2022"
 logo: images/logo-ocean-gliders.png
 html:
-  extra_footer: | <p> By the OceanGliders community using <a href="https://jupyterbook.org/intro.html"   target="_blank">Jupyter Book</a>. This work is licensed under a <a href="https://creativecommons.org/licenses/by/4.0/" target="_blank"> Creative Commons Attribution 4.0 Generic License.</a> </p>
+  extra_footer: |
+    <p>  By the OceanGliders community using
+      <a href="https://jupyterbook.org/intro.html"   target="_blank">Jupyter Book</a>. 
+      This work is licensed under a 
+      <a href="https://creativecommons.org/licenses/by/4.0/" target="_blank"> Creative Commons Attribution 4.0 Generic License.</a> 
+    </p>
 
 execute:
   execute_notebooks: "off"

--- a/_config.yml
+++ b/_config.yml
@@ -1,7 +1,11 @@
 title: "Oxygen SOP"
-author: The OceanGliders community
+#author: The OceanGliders community
 copyright: "2022"
 logo: images/logo-ocean-gliders.png
+html:
+  extra_footer:
+  <p> By the OceanGliders community using <a href="https://jupyterbook.org/intro.html"   target="_blank">Jupyter Book</a>. This work is licensed under a <a href="https://creativecommons.org/licenses/by/4.0/" target="_blank"> Creative Commons Attribution 4.0 Generic License.</a> </p>
+
 execute:
   execute_notebooks: "off"
 repository:

--- a/_config.yml
+++ b/_config.yml
@@ -1,6 +1,6 @@
 title: "Oxygen SOP"
-author: The OceanGliders community using [Jupyter Book](https://jupyterbook.org/intro.html) and is licensed under a [Creative Commons Attribution 4.0 Generic License](https://creativecommons.org/licenses/by/4.0/).
-copyright: "2021"
+author: The OceanGliders community
+copyright: "2021 under a [Creative Commons Attribution 4.0 Generic License](https://creativecommons.org/licenses/by/4.0/)"
 logo: images/logo-ocean-gliders.png
 execute:
   execute_notebooks: "off"

--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,5 @@
 title: "Oxygen SOP"
-author: The OceanGliders community
+author: The OceanGliders community using [Jupyter Book](https://jupyterbook.org/intro.html)
 copyright: "2021"
 logo: images/logo-ocean-gliders.png
 execute:

--- a/_config.yml
+++ b/_config.yml
@@ -1,6 +1,6 @@
 title: "Oxygen SOP"
 author: The OceanGliders community
-copyright: "2021"
+copyright: "2022"
 logo: images/logo-ocean-gliders.png
 execute:
   execute_notebooks: "off"

--- a/_config.yml
+++ b/_config.yml
@@ -1,6 +1,6 @@
 title: "Oxygen SOP"
 author: The OceanGliders community
-copyright: "2021 under a [Creative Commons Attribution 4.0 Generic License](https://creativecommons.org/licenses/by/4.0/)"
+copyright: "2021"
 logo: images/logo-ocean-gliders.png
 execute:
   execute_notebooks: "off"

--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,6 @@
 title: "Oxygen SOP"
 copyright: ""
+author: ""
 logo: images/logo-ocean-gliders.png
 
 execute:

--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,5 @@
 title: "Oxygen SOP"
-author: The OceanGliders community using [Jupyter Book](https://jupyterbook.org/intro.html)
+author: The OceanGliders community using [Jupyter Book](https://jupyterbook.org/intro.html) and is licensed under a [Creative Commons Attribution 4.0 Generic License](https://creativecommons.org/licenses/by/4.0/).
 copyright: "2021"
 logo: images/logo-ocean-gliders.png
 execute:

--- a/_config.yml
+++ b/_config.yml
@@ -1,4 +1,6 @@
 title: "Oxygen SOP"
+author: The OceanGliders community
+copyright: "2021"
 logo: images/logo-ocean-gliders.png
 execute:
   execute_notebooks: "off"


### PR DESCRIPTION
This pull-request will update the _config.yml file to add an extra_footer

- [x] credit jupyter books by writing "using Jupyter Book" + link to https://jupyterbook.org/intro.html) 
- [x] mention Creative Commons Attribution 4.0 Generic License + link to https://creativecommons.org/licenses/by/4.0/ which is also in the repo LINCENSE.md https://github.com/OceanGlidersCommunity/Oxygen_SOP/blob/main/LICENSE.md

This relates to issue #174 

After we merged this we have to implement the same for all SOPs.