### PR TITLE
Add pdf generation to build workflow.

### DIFF
--- a/.github/workflows/build_book.yml
+++ b/.github/workflows/build_book.yml
@@ -40,7 +40,6 @@ jobs:
       - name: Build the book as pdf
         run: |
           jupyter-book build . --builder pdfhtml
-          cp _build/pdf/book.pdf book.pdf
 
       # Zip the site (so it can be handed to the preview action)
       - name: Zip the site
@@ -55,6 +54,10 @@ jobs:
         with:
           name: site-zip
           path: ./site.zip
+      - uses: actions/upload-artifact@v2
+        with:
+          name: book-pdf
+          path: _build/pdf/book.pdf
 
       # Push the site's HTML to github-pages (only if on main, previews are sent to netlify)
       - name: Deploy to GitHub pages

--- a/.github/workflows/build_book.yml
+++ b/.github/workflows/build_book.yml
@@ -1,6 +1,6 @@
 name: deploy-site
 
-# Only run this when the master branch changes
+# Only run this when the main branch changes
 on:
   push:
     branches:
@@ -8,7 +8,7 @@ on:
   pull_request:
   workflow_dispatch:
 
-# This job installs dependencies, builds the book, and pushes it to `gh-pages`
+# This job installs dependencies, builds the book (+pdf), and pushes it to `gh-pages`
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -33,10 +33,13 @@ jobs:
         run: |
           pip install -r requirements.txt
 
-      # Build the book
       - name: Build the book
         run: |
           jupyter-book build .
+      
+      - name: Build the book as pdf
+        run: |
+          jupyter-book build . --builder pdfhtml
 
       # Zip the site (so it can be handed to the preview action)
       - name: Zip the site

--- a/.github/workflows/build_book.yml
+++ b/.github/workflows/build_book.yml
@@ -40,6 +40,7 @@ jobs:
       - name: Build the book as pdf
         run: |
           jupyter-book build . --builder pdfhtml
+          cp _build/pdf/book.pdf book.pdf
 
       # Zip the site (so it can be handed to the preview action)
       - name: Zip the site


### PR DESCRIPTION
Quick demo to add pdf generation to the `build_book` action. This should generate a pdf, that is accessible via the [action artifacts](url), but nowhere else. We can either download this manually or do something with it later. It is not visible from the repo main page, so folks dont get the impression that a pdf is the 'main' document.

cc @soerenthomsen 