### PR TITLE
add meeting notes from BP workshop 2021

### DIFF
--- a/sections/authors_SOP_development_process.md
+++ b/sections/authors_SOP_development_process.md
@@ -34,7 +34,7 @@
 
 1) Initial SOP was drafted by [Patricia López-García](https://github.com/patricialg), [Tom Hull](https://github.com/tomhull), [Soeren Thomsen](https://github.com/soerenthomsen) and [Johannes Hahn](https://github.com/hahn-johannes).
 
-2) Two expert sessions during OceanGliders Best Practice Workshop, May 11 - 25 2021. 
+2) Two expert sessions during OceanGliders Best Practice Workshop, May 11 - 25 2021. [Meeting Notes](https://github.com/OceanGlidersCommunity/Oxygen_SOP/commit/91683f50a4e08d95759dee66baa223ff6f7d533c)
 Additional authors joined: [Bastien Y. Queste](https://github.com/bastienqueste), [Gerd Krahmann](https://github.com/gkrahmann), [Charlotte Williams](https://github.com/charlotte-aj-williams), Mun Woo, Charitha Pattiaratchi, [Laurent Coppola](https://github.com/laurcopp), Tania Morales, [Virginie Racape](https://github.com/vracape), [Claire Gourcuff](https://github.com/cgourcuf), John Allen, [Eva Alou-Font](https://github.com/ealou), [Nikolaos D. Zarokanellos](https://github.com/nizaroka)
 
 3) First community and user feedback was provided during the OceanGliders Best Practice Workshop, May 11 - 25 2021 by attendees. 


### PR DESCRIPTION
I copied over the meeting notes of the OceanGliders Best Practice workshop and linked them in this section. 
They are a bit messy but better to have them here than not.