### PR TITLE
update actions/setup-python@v1->4

### DIFF
--- a/.github/workflows/build_book.yml
+++ b/.github/workflows/build_book.yml
@@ -71,7 +71,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
         with:
           python-version: 3.9
 


### PR DESCRIPTION
To avoid warnings as suggested by @castelao [here](https://github.com/OceanGlidersCommunity/DepthAverageCurrents_SOP/pull/123)